### PR TITLE
I've found that the issue is I was using chef 12.0.3, and in line 109 of

### DIFF
--- a/chef_metal_ssh.gemspec
+++ b/chef_metal_ssh.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.files = %w(Rakefile LICENSE.txt README.md) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   s.add_dependency 'chef'
-  s.add_dependency 'chef-metal', '~> 0.12'
+  #s.add_dependency 'chef-metal', '~> 0.12'
+  s.add_dependency 'chef-provisioning', '~> 0.17'
 
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rspec"

--- a/lib/chef/resource/ssh_cluster.rb
+++ b/lib/chef/resource/ssh_cluster.rb
@@ -14,8 +14,9 @@ class Chef::Resource::SshCluster < Chef::Resource::LWRPBase
     run_context.chef_metal.with_driver "ssh:#{path}"
   end
 
-  # We are not interested in Chef's cloning behavior here.
-  def load_prior_resource
+  # We are not interested in Chef's cloning behavior here. To make it match chef version after 
+  #CHEF-5052, https://tickets.opscode.com/browse/CHEF-5052
+  def load_prior_resource(type=nil,name=nil)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
   end
 end


### PR DESCRIPTION
/usr/local/rvm/gems/ruby-2.0.0-p598/gems/chef-12.0.3/lib/chef/dsl/recipe.rb

```
 resource.load_prior_resource(type, name)
```

But in chef-metal-ssh-0.1.2/lib/chef/resource/ssh_cluster.rb:18

it's defined as
def load_prior_resource
Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with
NOOP")
end
so it throws

ArgumentError: wrong number of arguments (2 for 0)
