### PR TITLE
Rewrite to chef-provisioning

### DIFF
--- a/chef_provisioning_ssh.gemspec
+++ b/chef_provisioning_ssh.gemspec
@@ -1,16 +1,16 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'chef_metal_ssh/version'
+require 'chef_provisioning_ssh/version'
 
 Gem::Specification.new do |s|
-  s.name          = "chef-metal-ssh"
-  s.version       = ChefMetalSsh::VERSION
+  s.name          = "chef-provisioning-ssh"
+  s.version       = ChefProvisioningSsh::VERSION
   s.platform      = Gem::Platform::RUBY
   s.author        = "Zack Zondlo"
   s.email         = "zackzondlo@gmail.com"
   s.extra_rdoc_files = ['README.md', 'LICENSE.txt' ]
-  s.summary = 'Provisioner for managing servers using ssh in Chef Metal.'
+  s.summary = 'Provisioner for managing servers using ssh in Chef Provisioning.'
   s.description = s.summary
   s.homepage = 'https://github.com/double-z/chef-metal-ssh'
 
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
   s.files = %w(Rakefile LICENSE.txt README.md) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   s.add_dependency 'chef'
-  #s.add_dependency 'chef-metal', '~> 0.12'
-  s.add_dependency 'chef-provisioning', '~> 0.17'
+  s.add_dependency 'chef-provisioning', '~> 0.12'
 
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rspec"

--- a/chef_provisioning_ssh.gemspec
+++ b/chef_provisioning_ssh.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files = %w(Rakefile LICENSE.txt README.md) + Dir.glob("{distro,lib,tasks,spec}/**/*", File::FNM_DOTMATCH).reject {|f| File.directory?(f) }
 
   s.add_dependency 'chef'
-  s.add_dependency 'chef-provisioning', '~> 0.12'
+  s.add_dependency 'chef-provisioning', '~> 0.17'
 
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rspec"

--- a/lib/chef/provisioning/driver_init/ssh.rb
+++ b/lib/chef/provisioning/driver_init/ssh.rb
@@ -1,0 +1,3 @@
+require 'chef/provisioning/ssh_driver'
+
+Chef::Provisioning.register_driver_class('ssh', Chef::Provisioning::SshDriver)

--- a/lib/chef/resource/ssh_cluster.rb
+++ b/lib/chef/resource/ssh_cluster.rb
@@ -1,5 +1,5 @@
 require 'chef/resource/lwrp_base'
-require 'chef_metal_ssh'
+require 'chef_provisioning_ssh'
 
 class Chef::Resource::SshCluster < Chef::Resource::LWRPBase
  self.resource_name = 'ssh_cluster'
@@ -11,10 +11,10 @@ class Chef::Resource::SshCluster < Chef::Resource::LWRPBase
 
   def after_created
     super
-    run_context.chef_metal.with_driver "ssh:#{path}"
+    run_context.chef_provisioning.with_driver "ssh:#{path}"
   end
 
-  # We are not interested in Chef's cloning behavior here. To make it match chef version after 
+  # We are not interested in Chef's cloning behavior here. To make it match chef version after
   #CHEF-5052, https://tickets.opscode.com/browse/CHEF-5052
   def load_prior_resource(type=nil,name=nil)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")

--- a/lib/chef_metal/driver_init/ssh.rb
+++ b/lib/chef_metal/driver_init/ssh.rb
@@ -1,3 +1,0 @@
-require 'chef_metal_ssh/ssh_driver'
-
-ChefMetal.register_driver_class('ssh', ChefMetalSsh::SshDriver)

--- a/lib/chef_metal_ssh/version.rb
+++ b/lib/chef_metal_ssh/version.rb
@@ -1,3 +1,0 @@
-module ChefMetalSsh
-  VERSION = "0.1.2"
-end

--- a/lib/chef_provisioning_ssh.rb
+++ b/lib/chef_provisioning_ssh.rb
@@ -1,10 +1,9 @@
-require 'chef_metal'
+require 'chef/provisioning'
 require 'chef/resource/ssh_cluster'
 require 'chef/provider/ssh_cluster'
 require 'chef/resource/ssh_target'
 require 'chef/provider/ssh_target'
-# require 'chef_metal_ssh/machine_registry'
-require 'chef_metal_ssh/ssh_driver'
+require 'chef/provisioning/ssh_driver'
 
 class Chef
 	module DSL

--- a/lib/chef_provisioning_ssh/machine_registry.rb
+++ b/lib/chef_provisioning_ssh/machine_registry.rb
@@ -1,6 +1,4 @@
-# require 'chef_metal_ssh'
-
-module ChefMetalSsh
+module ChefProvisioningSsh
   module MachineRegistry
 
     def validate_machine_options(node)
@@ -47,7 +45,7 @@ module ChefMetalSsh
     end
 
     def delete_provider_registration_file(action_handler, registry_file)
-      ChefMetal.inline_resource(action_handler) do
+      Chef::Provisioning.inline_resource(action_handler) do
         file registry_file do
           action :delete
         end
@@ -70,7 +68,7 @@ module ChefMetalSsh
 
       machine_options_json = JSON.pretty_generate(machine_options)
 
-      ChefMetal.inline_resource(action_handler) do
+      Chef::Provisioning.inline_resource(action_handler) do
         file machine_registration_file do
           content machine_options_json
         end

--- a/lib/chef_provisioning_ssh/version.rb
+++ b/lib/chef_provisioning_ssh/version.rb
@@ -1,0 +1,3 @@
+module ChefProvisioningSsh
+  VERSION = "0.1.2"
+end

--- a/test/cookbooks/ssh_test/recipes/both.rb
+++ b/test/cookbooks/ssh_test/recipes/both.rb
@@ -1,5 +1,5 @@
 # require 'chef_metal'
-require 'chef_metal_ssh'
+require 'chef_provisioning_ssh'
 
 # with_driver 'ssh'
 ssh_cluster_path = "/vagrant/test/ssh_cluster"

--- a/test/cookbooks/ssh_test/recipes/install_metal_local.rb
+++ b/test/cookbooks/ssh_test/recipes/install_metal_local.rb
@@ -11,7 +11,7 @@
 #  version '0.6'
 #end
 
-chef_gem 'chef-metal-ssh' do
-  source '/vagrant/pkg/chef-metal-ssh-0.1.2.gem'
+chef_gem 'chef-provisioning-ssh' do
+  source '/vagrant/pkg/chef-provisioning-ssh-0.1.2.gem'
   version '0.1.2'
 end


### PR DESCRIPTION
Rewrite code to chef-provisioning use only.
I didn't bump version and keep "metal" words what I hadn't to fix.
(exp.README, test ruby file names and so on)
